### PR TITLE
Enable using all arguments in the dojorc overridable by the command line

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -163,7 +163,8 @@ function serve(configs: webpack.Configuration[], args: any): Promise<void> {
 const CONFIG_DEFAULTS = {
 	legacy: false,
 	port: 9999,
-	mode: 'dist'
+	mode: 'dist',
+	serve: false
 };
 
 function filterCommandLineArgs(commandLineArgs: any) {
@@ -207,7 +208,8 @@ const command: Command = {
 		options('serve', {
 			describe: 'start a webserver',
 			alias: 's',
-			type: 'boolean'
+			type: 'boolean',
+			default: undefined
 		});
 
 		options('elements', {

--- a/tests/unit/main.ts
+++ b/tests/unit/main.ts
@@ -170,6 +170,7 @@ describe('command', () => {
 						legacy: false,
 						port: 9999,
 						mode: 'dist',
+						serve: false,
 						element: {
 							name: 'element',
 							path: 'element'
@@ -185,7 +186,7 @@ describe('command', () => {
 				legacy: true,
 				port: 9876,
 				mode: 'dev',
-				watch: true,
+				watch: 'memory',
 				serve: true,
 				elements: ['helloworld']
 			};
@@ -196,7 +197,7 @@ describe('command', () => {
 						legacy: true,
 						port: 9876,
 						mode: 'dev',
-						watch: true,
+						watch: 'memory',
 						serve: true,
 						element: {
 							name: 'helloworld',
@@ -213,7 +214,7 @@ describe('command', () => {
 				legacy: true,
 				port: 9876,
 				mode: 'dev',
-				watch: true,
+				watch: 'memory',
 				serve: true,
 				elements: ['helloworld']
 			};
@@ -231,7 +232,7 @@ describe('command', () => {
 							legacy: false,
 							port: 9876,
 							mode: 'dist',
-							watch: true,
+							watch: 'memory',
 							serve: true,
 							element: {
 								name: 'foo',
@@ -244,7 +245,7 @@ describe('command', () => {
 							legacy: false,
 							port: 9876,
 							mode: 'dist',
-							watch: true,
+							watch: 'memory',
 							serve: true,
 							element: {
 								name: 'bar',

--- a/tests/unit/main.ts
+++ b/tests/unit/main.ts
@@ -22,7 +22,7 @@ function getMockConfiguration(config: any = {}) {
 	return {
 		configuration: {
 			get() {
-				return { ...config, elements: ['element'] };
+				return { ...config, ...config.elements ? {} : { elements: ['element'] } };
 			}
 		}
 	};
@@ -91,7 +91,7 @@ describe('command', () => {
 			optionsStub.calledWith('mode', {
 				describe: 'the output mode',
 				alias: 'm',
-				default: 'dist',
+				default: undefined,
 				choices: ['dist', 'dev', 'test']
 			})
 		);
@@ -157,6 +157,102 @@ describe('command', () => {
 			assert.isTrue(mockModule.getMock('ora').ctor.calledWith('building'));
 			assert.isTrue(mockSpinner.start.called);
 			assert.isTrue(mockSpinner.stop.called);
+		});
+	});
+
+	describe('configuration', () => {
+		it('default options used when no options passed via command line or .dojorc', () => {
+			const main = mockModule.getModuleUnderTest().default;
+
+			return main.run(getMockConfiguration(), {}).then(() => {
+				assert.isTrue(
+					mockDistConfig.calledWith({
+						legacy: false,
+						port: 9999,
+						mode: 'dist',
+						element: {
+							name: 'element',
+							path: 'element'
+						}
+					})
+				);
+			});
+		});
+
+		it('should support all options being passed via the .dojorc', () => {
+			const main = mockModule.getModuleUnderTest().default;
+			const rcConfig = {
+				legacy: true,
+				port: 9876,
+				mode: 'dev',
+				watch: true,
+				serve: true,
+				elements: ['helloworld']
+			};
+
+			return main.run(getMockConfiguration(rcConfig), {}).then(() => {
+				assert.isTrue(
+					mockDevConfig.calledWith({
+						legacy: true,
+						port: 9876,
+						mode: 'dev',
+						watch: true,
+						serve: true,
+						element: {
+							name: 'helloworld',
+							path: 'helloworld'
+						}
+					})
+				);
+			});
+		});
+
+		it('commandLine options should override options provided by .dojorc', () => {
+			const main = mockModule.getModuleUnderTest().default;
+			const rcConfig = {
+				legacy: true,
+				port: 9876,
+				mode: 'dev',
+				watch: true,
+				serve: true,
+				elements: ['helloworld']
+			};
+
+			return main
+				.run(getMockConfiguration(rcConfig), {
+					elements: ['foo', 'bar'],
+					mode: 'dist',
+					watch: undefined,
+					legacy: false
+				})
+				.then(() => {
+					assert.isTrue(
+						mockDistConfig.firstCall.calledWith({
+							legacy: false,
+							port: 9876,
+							mode: 'dist',
+							watch: true,
+							serve: true,
+							element: {
+								name: 'foo',
+								path: 'foo'
+							}
+						})
+					);
+					assert.isTrue(
+						mockDistConfig.secondCall.calledWith({
+							legacy: false,
+							port: 9876,
+							mode: 'dist',
+							watch: true,
+							serve: true,
+							element: {
+								name: 'bar',
+								path: 'bar'
+							}
+						})
+					);
+				});
 		});
 	});
 


### PR DESCRIPTION
Type: **bug**

**Description**

Enables using all command line arguments to be set within the `.dojorc` but overridable with command line arguments.

Resolves: #13 