### PR TITLE
Support standard NODE_ENV for production builds

### DIFF
--- a/src/dist.config.ts
+++ b/src/dist.config.ts
@@ -29,7 +29,12 @@ function webpackConfig(args: any): webpack.Configuration {
 		}),
 		new UglifyJsPlugin({ sourceMap: true, cache: true }),
 		new WebpackChunkHash(),
-		new CleanWebpackPlugin([location], { root: output.path, verbose: false })
+		new CleanWebpackPlugin([location], { root: output.path, verbose: false }),
+		new webpack.DefinePlugin({
+			'process.env': {
+				NODE_ENV: '"production"'
+			}
+		})
 	];
 
 	config.plugins = config.plugins.map(plugin => {


### PR DESCRIPTION
Adding DefinePlugin for production builds to add NODE_ENV.