### PR TITLE
Building elements in a single config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4295,9 +4295,9 @@
       }
     },
     "ecstatic": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/ecstatic/-/ecstatic-3.3.0.tgz",
-      "integrity": "sha512-EblWYTd+wPIAMQ0U4oYJZ7QBypT9ZUIwpqli0bKDjeIIQnXDBK2dXtZ9yzRCOlkW1HkO8gn7/FxLK1yPIW17pw==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/ecstatic/-/ecstatic-3.3.1.tgz",
+      "integrity": "sha512-/rrctvxZ78HMI/tPIsqdvFKHHscxR3IJuKrZI2ZoUgkt2SiufyLFBmcco+aqQBIu6P1qBsUNG3drAAGLx80vTQ==",
       "requires": {
         "he": "^1.1.1",
         "mime": "^1.6.0",
@@ -4557,9 +4557,9 @@
       }
     },
     "eventemitter3": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
-      "integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA=="
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
     },
     "events": {
       "version": "3.0.0",
@@ -5144,7 +5144,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5162,11 +5163,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5179,15 +5182,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5290,7 +5296,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5300,6 +5307,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5312,17 +5320,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5339,6 +5350,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5411,7 +5423,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5421,6 +5434,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5496,7 +5510,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5526,6 +5541,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5543,6 +5559,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5581,11 +5598,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "cpx": "~1.5.0",
     "cypress": "3.1.3",
     "execa": "0.8.0",
+    "http-server": "^0.11.1",
     "husky": "^0.14.3",
     "lint-staged": "6.0.0",
     "mockery": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "cpx": "~1.5.0",
     "cypress": "3.1.3",
     "execa": "0.8.0",
-    "http-server": "^0.11.1",
+    "http-server": "0.11.1",
     "husky": "^0.14.3",
     "lint-staged": "6.0.0",
     "mockery": "2.1.0",

--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -175,9 +175,8 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 						{
 							loader: 'ts-loader',
 							options: {
-								onlyCompileBundledFiles: false,
+								onlyCompileBundledFiles: true,
 								instance: jsonpIdent,
-								transpileOnly: false,
 								compilerOptions
 							}
 						}

--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -116,8 +116,8 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 		}, {}),
 		node: { dgram: 'empty', net: 'empty', tls: 'empty', fs: 'empty' },
 		output: {
-			chunkFilename: `[name]/[name]-${packageJson.version}.js`,
-			filename: `[name]/[name]-${packageJson.version}.js`,
+			chunkFilename: `[name]-${packageJson.version}.js`,
+			filename: `[name]-${packageJson.version}.js`,
 			jsonpFunction: getJsonpFunctionName(`-${packageName}-${jsonpIdent}`),
 			libraryTarget: 'jsonp',
 			path: path.resolve('./output'),
@@ -133,7 +133,7 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 			new webpack.BannerPlugin(banner),
 			new IgnorePlugin(/request\/providers\/node/),
 			new MiniCssExtractPlugin({
-				filename: `[name]/[name]-${packageJson.version}.css`,
+				filename: `[name]-${packageJson.version}.css`,
 				sourceMap: true
 			} as any)
 		]),

--- a/src/dev.config.ts
+++ b/src/dev.config.ts
@@ -7,12 +7,13 @@ function webpackConfig(args: any): webpack.Configuration {
 	const config = baseConfigFactory(args);
 	const { plugins, output } = config;
 	const outputPath = output!.path as string;
+	const location = path.join(outputPath, 'dev');
 
-	config.plugins = [...plugins!, new CleanWebpackPlugin([outputPath], { root: outputPath, verbose: false })];
+	config.plugins = [...plugins!, new CleanWebpackPlugin([location], { root: outputPath, verbose: false })];
 
 	config.output = {
 		...output,
-		path: path.join(outputPath, 'dev')
+		path: location
 	};
 
 	config.devtool = 'inline-source-map';

--- a/src/dev.config.ts
+++ b/src/dev.config.ts
@@ -1,4 +1,5 @@
 import baseConfigFactory from './base.config';
+import * as path from 'path';
 import * as webpack from 'webpack';
 import * as CleanWebpackPlugin from 'clean-webpack-plugin';
 
@@ -8,6 +9,11 @@ function webpackConfig(args: any): webpack.Configuration {
 	const outputPath = output!.path as string;
 
 	config.plugins = [...plugins!, new CleanWebpackPlugin([outputPath], { root: outputPath, verbose: false })];
+
+	config.output = {
+		...output,
+		path: path.join(outputPath, 'dev')
+	};
 
 	config.devtool = 'inline-source-map';
 	return config;

--- a/src/dev.config.ts
+++ b/src/dev.config.ts
@@ -1,20 +1,13 @@
 import baseConfigFactory from './base.config';
-import * as path from 'path';
 import * as webpack from 'webpack';
 import * as CleanWebpackPlugin from 'clean-webpack-plugin';
 
 function webpackConfig(args: any): webpack.Configuration {
 	const config = baseConfigFactory(args);
 	const { plugins, output } = config;
-	const location = path.join('dev', args.element.name);
 	const outputPath = output!.path as string;
 
-	config.plugins = [...plugins!, new CleanWebpackPlugin([location], { root: outputPath, verbose: false })];
-
-	config.output = {
-		...output,
-		path: path.join(outputPath, location)
-	};
+	config.plugins = [...plugins!, new CleanWebpackPlugin([outputPath], { root: outputPath, verbose: false })];
 
 	config.devtool = 'inline-source-map';
 	return config;

--- a/src/dist.config.ts
+++ b/src/dist.config.ts
@@ -12,6 +12,7 @@ function webpackConfig(args: any): webpack.Configuration {
 	const config = baseConfigFactory(args);
 	const { plugins, output } = config;
 	const outputPath = output!.path as string;
+	const location = path.join(outputPath, 'dist');
 
 	config.mode = 'production';
 
@@ -38,12 +39,12 @@ function webpackConfig(args: any): webpack.Configuration {
 			statsFilename: '../info/stats.json'
 		}),
 		new WebpackChunkHash(),
-		new CleanWebpackPlugin([outputPath], { root: outputPath, verbose: false })
+		new CleanWebpackPlugin([location], { root: outputPath, verbose: false })
 	];
 
 	config.output = {
 		...output,
-		path: path.join(outputPath, 'dist')
+		path: location
 	};
 
 	return config;

--- a/src/dist.config.ts
+++ b/src/dist.config.ts
@@ -1,6 +1,7 @@
 import BundleAnalyzerPlugin from '@dojo/webpack-contrib/webpack-bundle-analyzer/BundleAnalyzerPlugin';
 import baseConfigFactory from './base.config';
 import webpack = require('webpack');
+import * as path from 'path';
 import * as CleanWebpackPlugin from 'clean-webpack-plugin';
 import * as WebpackChunkHash from 'webpack-chunk-hash';
 
@@ -39,6 +40,11 @@ function webpackConfig(args: any): webpack.Configuration {
 		new WebpackChunkHash(),
 		new CleanWebpackPlugin([outputPath], { root: outputPath, verbose: false })
 	];
+
+	config.output = {
+		...output,
+		path: path.join(outputPath, 'dist')
+	};
 
 	return config;
 }

--- a/src/dist.config.ts
+++ b/src/dist.config.ts
@@ -1,7 +1,6 @@
 import BundleAnalyzerPlugin from '@dojo/webpack-contrib/webpack-bundle-analyzer/BundleAnalyzerPlugin';
 import baseConfigFactory from './base.config';
 import webpack = require('webpack');
-import * as path from 'path';
 import * as CleanWebpackPlugin from 'clean-webpack-plugin';
 import * as WebpackChunkHash from 'webpack-chunk-hash';
 
@@ -11,7 +10,6 @@ const TerserPlugin = require('terser-webpack-plugin');
 function webpackConfig(args: any): webpack.Configuration {
 	const config = baseConfigFactory(args);
 	const { plugins, output } = config;
-	const location = path.join('dist', args.element.name);
 	const outputPath = output!.path as string;
 
 	config.mode = 'production';
@@ -39,13 +37,8 @@ function webpackConfig(args: any): webpack.Configuration {
 			statsFilename: '../info/stats.json'
 		}),
 		new WebpackChunkHash(),
-		new CleanWebpackPlugin([location], { root: outputPath, verbose: false })
+		new CleanWebpackPlugin([outputPath], { root: outputPath, verbose: false })
 	];
-
-	config.output = {
-		...output,
-		path: path.join(outputPath, location)
-	};
 
 	return config;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -223,11 +223,11 @@ const command: Command = {
 		});
 		let configs: webpack.Configuration[];
 		if (args.mode === 'dev') {
-			configs = elements.map((element: any) => devConfigFactory({ ...rc, ...commandLineArgs, element }));
+			configs = [devConfigFactory({ ...rc, ...commandLineArgs, elements })];
 		} else if (args.mode === 'test') {
 			configs = [testConfigFactory({ ...rc, ...commandLineArgs, elements, legacy: true })];
 		} else {
-			configs = elements.map((element: any) => distConfigFactory({ ...rc, ...commandLineArgs, element }));
+			configs = [distConfigFactory({ ...rc, ...commandLineArgs, elements })];
 		}
 
 		if (configs.length === 0) {

--- a/test-app/src/evergreen.html
+++ b/test-app/src/evergreen.html
@@ -4,8 +4,8 @@
 	<title>custom-element</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<script src="../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
-	<script src="./menu/menu-1.0.0.js"></script>
-	<script src="./menu-item/menu-item-1.0.0.js"></script>
+	<script src="./menu-1.0.0.js"></script>
+	<script src="./menu-item-1.0.0.js"></script>
 	<link rel="stylesheet" href="./menu/menu-1.0.0.css" />
 	<link rel="stylesheet" href="./menu-item/menu-item-1.0.0.css" />
 </head>

--- a/test-app/src/legacy.html
+++ b/test-app/src/legacy.html
@@ -5,8 +5,8 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<script src="../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
 	<script src="../../node_modules/@webcomponents/webcomponentsjs/custom-elements-es5-adapter.js"></script>
-	<script src="./menu/menu-1.0.0.js"></script>
-	<script src="./menu-item/menu-item-1.0.0.js"></script>
+	<script src="./menu-1.0.0.js"></script>
+	<script src="./menu-item-1.0.0.js"></script>
 	<link rel="stylesheet" href="./menu/menu-1.0.0.css" />
 	<link rel="stylesheet" href="./menu-item/menu-item-1.0.0.css" />
 </head>

--- a/test-app/src/menu/Menu.ts
+++ b/test-app/src/menu/Menu.ts
@@ -42,7 +42,8 @@ export class Menu extends ThemedMixin(WidgetBase)<MenuProperties, WNode<MenuItem
 			return child;
 		});
 
-		const navAttributes = { classes: this.theme(css.root) };
+		const navAttributes: any = { classes: this.theme(css.root) };
+
 		if (has('foo')) {
 			navAttributes['data-foo'] = 'true';
 		}


### PR DESCRIPTION
Instead of passing a single webpack configuration for each element being built, this is passing a single webpack configuration for all elements. Previously, it would crash if you turned off `onlyCompileBundledFiles` in `ts-loader` and ran it on @dojo/widgets because it would run out of memory. In theory this was because each configuration would be loading all the dependencies together and there would be no sharing between them. Remember webpack, sharing is caring!

When running this locally, it'd produce the following structure for @dojo/widgets,

```
output/
    accordian-pane/
        accordian-pane-1.0.0.js
        accordian-pane-1.0.0.css
    button/
    rinse, lather, repeat for all widgets
    blahblah.svg
    blahblah2.ttf
```

- Compared to the current version of cli-build-webpack, it's missing the `dist` directory under `output/`. This shouldn't be difficult to include.
- I was having trouble getting `file-loader` to copy those svg/ttf assets into each widgets directory instead of just leaving them at the root.

I tested that the widgets were being created correctly by quickly creating an example page for the button widget and pulling in the dependencies. Things seemed like they were working fine, but a better test might be to generate everything and then copy the resulting files into the custom element showcase.