### PR TITLE
Updates for custom element transformer

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "typescript": "3.4.5"
   },
   "dependencies": {
-    "@dojo/framework": "6.0.0-alpha.7",
+    "@dojo/framework": "6.0.0-alpha.12",
     "@dojo/webpack-contrib": "6.0.0-alpha.8",
     "chalk": "2.4.1",
     "clean-webpack-plugin": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -95,8 +95,8 @@
     "typescript": "3.4.5"
   },
   "dependencies": {
-    "@dojo/framework": "6.0.0-alpha.12",
-    "@dojo/webpack-contrib": "6.0.0-alpha.8",
+    "@dojo/framework": "6.0.0-alpha.15",
+    "@dojo/webpack-contrib": "6.0.0-alpha.10",
     "chalk": "2.4.1",
     "clean-webpack-plugin": "1.0.0",
     "cli-columns": "3.1.2",

--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -146,10 +146,11 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 		getCustomTransformers(program: any) {
 			return {
 				before: removeEmpty([
-					elementTransformer(program, {
-						elementPrefix,
-						customElementFiles: widgets.map((widget: any) => path.resolve(widget.path))
-					}),
+					args.target !== 'lib' &&
+						elementTransformer(program, {
+							elementPrefix,
+							customElementFiles: widgets.map((widget: any) => path.resolve(widget.path))
+						}),
 					emitAll && emitAll.transformer
 				])
 			};

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -15,7 +15,7 @@
     "build:lib-app": "dojo build app && shx mv output/dist output/dist-lib-evergreen"
   },
   "dependencies": {
-    "@dojo/framework": "6.0.0-alpha.12",
+    "@dojo/framework": "6.0.0-alpha.15",
     "@webcomponents/custom-elements": "1.0.8",
     "tslib": "~1.9.0",
     "typescript": "3.4.5"

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -15,7 +15,7 @@
     "build:lib-app": "dojo build app && shx mv output/dist output/dist-lib-evergreen"
   },
   "dependencies": {
-    "@dojo/framework": "6.0.0-alpha.7",
+    "@dojo/framework": "6.0.0-alpha.12",
     "@webcomponents/custom-elements": "1.0.8",
     "tslib": "~1.9.0",
     "typescript": "3.4.5"

--- a/test-app/src/menu/Menu.ts
+++ b/test-app/src/menu/Menu.ts
@@ -1,61 +1,56 @@
-import has from '@dojo/framework/core/has';
-import { v } from '@dojo/framework/core/vdom';
-import { DNode, WidgetProperties, WNode } from '@dojo/framework/core/interfaces';
-import { theme, ThemedMixin } from '@dojo/framework/core/mixins/Themed';
-import { WidgetBase } from '@dojo/framework/core/WidgetBase';
-import { MenuItem, MenuItemProperties } from '../menu-item/MenuItem';
-
+import { v, create, isWNode, isVNode } from '@dojo/framework/core/vdom';
+import { WidgetProperties } from '@dojo/framework/core/interfaces';
+import { MenuItemProperties } from '../menu-item/MenuItem';
+import icache from '@dojo/framework/core/middleware/icache';
+import theme from '@dojo/framework/core/middleware/theme';
 import * as css from './menu.m.css';
+import has from '@dojo/framework/core/has';
 
 export interface MenuProperties extends WidgetProperties {
 	onSelected: (data: any) => void;
 }
 
-@theme(css)
-export class Menu extends ThemedMixin(WidgetBase)<MenuProperties, WNode<MenuItem>> {
-	private _selectedId: number | undefined;
+const render = create({ icache, theme }).properties<MenuProperties>();
 
-	private _onSelected(id: number, data: any) {
-		this._selectedId = id;
-		this.properties.onSelected(data);
-		this.invalidate();
-	}
-
-	protected render(): DNode {
-		const items = this.children.map((child, index) => {
-			if (child) {
-				const properties: Partial<MenuItemProperties> = {
-					onSelected: (data: any) => {
-						this._onSelected(index, data);
-					}
-				};
-				if (this._selectedId !== undefined) {
-					properties.selected = index === this._selectedId;
+export const Menu = render(({ properties, children, middleware: { icache, theme } }) => {
+	const { onSelected } = properties();
+	const themedCss = theme.classes(css);
+	const items = children().map((child, index) => {
+		if (isWNode(child) || isVNode(child)) {
+			const properties: Partial<MenuItemProperties> = {
+				onSelected: (data: any) => {
+					onSelected(data);
+					icache.set('selectedId', index);
 				}
-				child.properties = { ...child.properties, ...properties };
+			};
+			const selectedId = icache.get<number>('selectedId');
+			if (typeof selectedId !== 'undefined') {
+				properties.selected = index === selectedId;
 			}
-			return child;
-		});
-
-		const navAttributes: any = { classes: this.theme(css.root) };
-
-		if (has('foo')) {
-			navAttributes['data-foo'] = 'true';
-		}
-		if (has('bar')) {
-			navAttributes['data-bar'] = 'true';
+			child.properties = { ...child.properties, ...properties };
 		}
 
-		return v('nav', navAttributes, [
-			v(
-				'ol',
-				{
-					classes: this.theme(css.menuContainer)
-				},
-				items
-			)
-		]);
+		return child;
+	});
+
+	const navAttributes: any = { classes: themedCss.root };
+
+	if (has('foo')) {
+		navAttributes['data-foo'] = 'true';
 	}
-}
+	if (has('bar')) {
+		navAttributes['data-bar'] = 'true';
+	}
+
+	return v('nav', navAttributes, [
+		v(
+			'ol',
+			{
+				classes: themedCss.menuContainer
+			},
+			items
+		)
+	]);
+});
 
 export default Menu;

--- a/test-lib-app/package.json
+++ b/test-lib-app/package.json
@@ -9,7 +9,7 @@
     "build:dev:evergreen": "shx mv widget-lib-build/dev-lib src/widget-lib && dojo build -m dev && shx mv output/dev output/dev-lib && rimraf src/widget-lib"
   },
   "dependencies": {
-    "@dojo/framework": "6.0.0-alpha.7",
+    "@dojo/framework": "6.0.0-alpha.15",
     "tslib": "~1.8.1"
   },
   "devDependencies": {


### PR DESCRIPTION
* Updates framework dependencies to `6.0.0-alpha.12` for latest function-based widget API
* Converts Menu to a function-based widget to test transformer updates
* Removes custom element transformer from lib build. Evidently these custom elements would not be usable anyways, and the `onlyCompileBundledFiles` flag used for that build means that the TS `checker` in the transformer can't see the types from `@dojo/framework` which is necessary for the function-based custom element transformation.

This shouldn't be merged until webpack-contrib and framework are both released with the needed changes.