### PR TITLE
Use rootDir of src to ensure widgets are output correctly

### DIFF
--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -140,6 +140,7 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 				? {
 						...compilerOptions,
 						declaration: true,
+						rootDir: './src',
 						outDir: path.resolve(`./output/${args.mode || 'dist'}`)
 					}
 				: compilerOptions,

--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -140,7 +140,7 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 				? {
 						...compilerOptions,
 						declaration: true,
-						rootDir: './src',
+						rootDir: path.resolve('./src'),
 						outDir: path.resolve(`./output/${args.mode || 'dist'}`)
 					}
 				: compilerOptions,


### PR DESCRIPTION
When building a single widget using the library target the type definitions file is output into the root rather than the widget directory. This is because the common root is the widgets directory, using `rootDir` of `src` ensure that the source folder/file structure is maintained for the output even when there is only a single widget to build.

Resolves #65 