### PR TITLE
Discovering spec files in src directory

### DIFF
--- a/src/test.config.ts
+++ b/src/test.config.ts
@@ -13,7 +13,7 @@ function webpackConfig(args: any): webpack.Configuration {
 	const outputPath = output!.path as string;
 	config.entry = () => {
 		const unit = globby
-			.sync([`${basePath}/tests/unit/**/*.ts`])
+			.sync([`${basePath}/tests/unit/**/*.{ts,tsx}`, `${basePath}/src/**/*.spec.{ts,tsx}`])
 			.map((filename: string) => filename.replace(/\.ts$/, ''));
 
 		const functional = globby


### PR DESCRIPTION
Adding discovery of unit tests as `.spec.ts` and `.spec.tsx` files in the src directory along side the unit tests in the tests/unit directory. 

I tested this by renaming a test file in `@dojo/widgets` and doing a test build with `dojo build widget -m test` and then looking at the output and verified that the test was included.

This issue resolves https://github.com/dojo/cli-build-widget/issues/73