### PR TITLE
Deprecating test build and adding unit and functional builds

### DIFF
--- a/src/ejected.config.ts
+++ b/src/ejected.config.ts
@@ -2,11 +2,12 @@ import * as webpack from 'webpack';
 
 import devConfigFactory from './dev.config';
 import distConfigFactory from './dist.config';
-import testConfigFactory from './test.config';
+import unitTestConfigFactory from './unit.config';
+import functionalTestConfigFactory from './functional.config';
 import { getWidgetName } from './util';
 
 export interface EnvOptions {
-	mode?: 'dev' | 'dist' | 'test';
+	mode?: 'dev' | 'dist' | 'test' | 'unit' | 'functional';
 	target?: 'custom element' | 'lib';
 }
 
@@ -23,8 +24,10 @@ function webpackConfig(env: EnvOptions = {}): webpack.Configuration[] {
 
 	if (mode === 'dev') {
 		configs = [devConfigFactory({ ...rc, widgets, target })];
-	} else if (mode === 'test') {
-		configs = [testConfigFactory({ ...rc, widgets, target })];
+	} else if (mode === 'unit' || mode === 'test') {
+		configs = [unitTestConfigFactory({ ...rc, widgets, target })];
+	} else if (mode === 'functional') {
+		configs = [functionalTestConfigFactory({ ...rc, widgets, target })];
 	} else {
 		configs = [distConfigFactory({ ...rc, widgets, target })];
 	}

--- a/src/functional.config.ts
+++ b/src/functional.config.ts
@@ -1,0 +1,72 @@
+import baseConfigFactory from './base.config';
+import * as path from 'path';
+import * as webpack from 'webpack';
+import * as globby from 'globby';
+import * as CleanWebpackPlugin from 'clean-webpack-plugin';
+
+const basePath = process.cwd();
+
+function webpackConfig(args: any): webpack.Configuration {
+	const config = baseConfigFactory(args);
+	const { plugins, output, module } = config;
+	const instrumenterOptions = args.legacy ? {} : { esModules: true };
+	const outputPath = output!.path as string;
+	config.entry = () => {
+		const functional = globby
+			.sync([`${basePath}/tests/functional/**/*.{ts,tsx}`])
+			.map((filename: string) => filename.replace(/\.ts$/, ''));
+
+		const tests: any = {};
+
+		if (functional.length) {
+			tests.all = functional;
+		}
+
+		return tests;
+	};
+	const externals: any[] = (config.externals as any[]) || [];
+
+	config.plugins = [...plugins!, new CleanWebpackPlugin(['test'], { root: outputPath, verbose: false })];
+
+	if (module) {
+		module.rules = module.rules.map(rule => {
+			if (Array.isArray(rule.use)) {
+				rule.use = rule.use.map(loader => {
+					if (typeof loader === 'string') {
+						return loader;
+					}
+					const { loader: loaderName } = loader as webpack.RuleSetLoader;
+					if (loaderName === 'umd-compat-loader') {
+						return {
+							loader: loaderName,
+							options: {}
+						};
+					}
+					return loader;
+				});
+			}
+			return rule;
+		});
+		module.rules.push({
+			test: /src[\\\/].*\.ts(x)?$/,
+			use: {
+				loader: 'istanbul-instrumenter-loader',
+				options: instrumenterOptions
+			},
+			enforce: 'post'
+		});
+	}
+
+	externals.push(/^intern/);
+	config.externals = externals;
+	config.devtool = 'inline-source-map';
+	config.output = {
+		...output,
+		chunkFilename: '[name].js',
+		filename: '[name].js',
+		path: path.join(outputPath, 'test', 'functional')
+	};
+	return config;
+}
+
+export default webpackConfig;

--- a/src/unit.config.ts
+++ b/src/unit.config.ts
@@ -16,20 +16,12 @@ function webpackConfig(args: any): webpack.Configuration {
 			.sync([`${basePath}/tests/unit/**/*.{ts,tsx}`, `${basePath}/src/**/*.spec.{ts,tsx}`])
 			.map((filename: string) => filename.replace(/\.ts$/, ''));
 
-		const functional = globby
-			.sync([`${basePath}/tests/functional/**/*.ts`])
-			.map((filename: string) => filename.replace(/\.ts$/, ''));
-
 		const tests: any = {};
 
 		if (unit.length) {
-			tests.unit = unit;
-		}
-
-		if (functional.length) {
-			tests.functional = functional;
-		}
-
+			tests.all = unit;
+        }
+        
 		return tests;
 	};
 	const externals: any[] = (config.externals as any[]) || [];
@@ -69,10 +61,10 @@ function webpackConfig(args: any): webpack.Configuration {
 	config.externals = externals;
 	config.devtool = 'inline-source-map';
 	config.output = {
-		...output,
-		chunkFilename: `[name].js`,
-		filename: '[name].js',
-		path: path.join(outputPath, 'test')
+        ...output,
+        chunkFilename: '[name].js',
+        filename: '[name].js',
+		path: path.join(outputPath, 'test', 'unit')
 	};
 	return config;
 }

--- a/src/unit.config.ts
+++ b/src/unit.config.ts
@@ -20,8 +20,8 @@ function webpackConfig(args: any): webpack.Configuration {
 
 		if (unit.length) {
 			tests.all = unit;
-        }
-        
+		}
+
 		return tests;
 	};
 	const externals: any[] = (config.externals as any[]) || [];
@@ -61,9 +61,9 @@ function webpackConfig(args: any): webpack.Configuration {
 	config.externals = externals;
 	config.devtool = 'inline-source-map';
 	config.output = {
-        ...output,
-        chunkFilename: '[name].js',
-        filename: '[name].js',
+		...output,
+		chunkFilename: '[name].js',
+		filename: '[name].js',
 		path: path.join(outputPath, 'test', 'unit')
 	};
 	return config;

--- a/tests/unit/ejected.config.ts
+++ b/tests/unit/ejected.config.ts
@@ -7,14 +7,21 @@ const configJson: any = { widgets: ['widget'] };
 let mockModule: MockModule;
 let mockDevConfig: any;
 let mockDistConfig: any;
-let mockTestConfig: any;
+let mockUnitTestConfig: any;
+let mockFunctionalTestConfig: any;
 
 describe('ejected config', () => {
 	beforeEach(() => {
 		mockModule = new MockModule('../../src/ejected.config', require);
-		mockModule.dependencies(['./dev.config', './dist.config', './test.config', './build-options.json']);
+		mockModule.dependencies([
+			'./dev.config',
+			'./dist.config',
+			'./unit.config',
+			'./functional.config',
+			'./build-options.json'
+		]);
 
-		const configs = ['dev', 'dist', 'test'].map(name => {
+		const configs = ['dev', 'dist', 'unit', 'functional'].map(name => {
 			const config = mockModule.getMock(`./${name}.config`);
 			config.default = stub();
 			return config.default;
@@ -23,7 +30,8 @@ describe('ejected config', () => {
 		Object.assign(mockModule.getMock('./build-options.json'), configJson);
 		mockDevConfig = configs[0];
 		mockDistConfig = configs[1];
-		mockTestConfig = configs[2];
+		mockUnitTestConfig = configs[2];
+		mockFunctionalTestConfig = configs[3];
 	});
 
 	afterEach(() => {
@@ -49,12 +57,21 @@ describe('ejected config', () => {
 			);
 		});
 
-		it('can run test mode', () => {
+		it('can run unit mode', () => {
 			const config = mockModule.getModuleUnderTest();
-			config({ mode: 'test' });
-			assert.isTrue(mockTestConfig.calledOnce);
+			config({ mode: 'unit' });
+			assert.isTrue(mockUnitTestConfig.calledOnce);
 			assert.isTrue(
-				mockTestConfig.calledWith({ widgets: [{ name: 'widget', path: 'widget' }], target: 'custom element' })
+				mockUnitTestConfig.calledWith({ widgets: [{ name: 'widget', path: 'widget' }], target: 'custom element' })
+			);
+		});
+
+		it('can run functional mode', () => {
+			const config = mockModule.getModuleUnderTest();
+			config({ mode: 'functional' });
+			assert.isTrue(mockFunctionalTestConfig.calledOnce);
+			assert.isTrue(
+				mockFunctionalTestConfig.calledWith({ widgets: [{ name: 'widget', path: 'widget' }], target: 'custom element' })
 			);
 		});
 	});
@@ -74,11 +91,20 @@ describe('ejected config', () => {
 			assert.isTrue(mockDistConfig.calledWith({ widgets: [{ name: 'widget', path: 'widget' }], target: 'lib' }));
 		});
 
-		it('can run test mode', () => {
+		it('can run unit mode', () => {
 			const config = mockModule.getModuleUnderTest();
-			config({ mode: 'test', target: 'lib' });
-			assert.isTrue(mockTestConfig.calledOnce);
-			assert.isTrue(mockTestConfig.calledWith({ widgets: [{ name: 'widget', path: 'widget' }], target: 'lib' }));
+			config({ mode: 'unit', target: 'lib' });
+			assert.isTrue(mockUnitTestConfig.calledOnce);
+			assert.isTrue(mockUnitTestConfig.calledWith({ widgets: [{ name: 'widget', path: 'widget' }], target: 'lib' }));
+		});
+
+		it('can run functional mode', () => {
+			const config = mockModule.getModuleUnderTest();
+			config({ mode: 'functional', target: 'lib' });
+			assert.isTrue(mockFunctionalTestConfig.calledOnce);
+			assert.isTrue(
+				mockFunctionalTestConfig.calledWith({ widgets: [{ name: 'widget', path: 'widget' }], target: 'lib' })
+			);
 		});
 	});
 });


### PR DESCRIPTION
To bring cli-build-widget into alignment with cli-build-app, I deprecated the `test` mode, and added separate `unit` and `functional` modes.  These modes will output the bundles in the same place as `cli-build-app` so we can test with cli-test-intern.

Resolves #75