### PR TITLE
Excluding spec files from coverage

### DIFF
--- a/src/functional.config.ts
+++ b/src/functional.config.ts
@@ -53,6 +53,7 @@ function webpackConfig(args: any): webpack.Configuration {
 				loader: 'istanbul-instrumenter-loader',
 				options: instrumenterOptions
 			},
+			exclude: /\.spec\.ts(x)?$/,
 			enforce: 'post'
 		});
 	}

--- a/src/unit.config.ts
+++ b/src/unit.config.ts
@@ -53,7 +53,7 @@ function webpackConfig(args: any): webpack.Configuration {
 				loader: 'istanbul-instrumenter-loader',
 				options: instrumenterOptions
 			},
-			exclude: [/src[\\\/].*\.spec\.ts(x)?$/, /test[\\\/].*\.ts(x)?$/],
+			exclude: /\.spec\.ts(x)?$/,
 			enforce: 'post'
 		});
 	}

--- a/src/unit.config.ts
+++ b/src/unit.config.ts
@@ -53,6 +53,7 @@ function webpackConfig(args: any): webpack.Configuration {
 				loader: 'istanbul-instrumenter-loader',
 				options: instrumenterOptions
 			},
+			exclude: [/src[\\\/].*\.spec\.ts(x)?$/, /test[\\\/].*\.ts(x)?$/],
 			enforce: 'post'
 		});
 	}


### PR DESCRIPTION
Excluding `.spec.ts` and `.spec.tsx` files from istanbul instrumentation