### PR TITLE
Switching to webpack-contribs istanbul-loader

### DIFF
--- a/src/functional.config.ts
+++ b/src/functional.config.ts
@@ -50,7 +50,7 @@ function webpackConfig(args: any): webpack.Configuration {
 		module.rules.push({
 			test: /src[\\\/].*\.ts(x)?$/,
 			use: {
-				loader: 'istanbul-instrumenter-loader',
+				loader: '@dojo/webpack-contrib/istanbul-loader',
 				options: instrumenterOptions
 			},
 			enforce: 'post'

--- a/src/unit.config.ts
+++ b/src/unit.config.ts
@@ -14,7 +14,7 @@ function webpackConfig(args: any): webpack.Configuration {
 	config.entry = () => {
 		const unit = globby
 			.sync([`${basePath}/tests/unit/**/*.{ts,tsx}`, `${basePath}/src/**/*.spec.{ts,tsx}`])
-			.map((filename: string) => filename.replace(/\.ts$/, ''));
+			.map((filename: string) => filename.replace(/\.tsx?$/, ''));
 
 		const tests: any = {};
 
@@ -50,7 +50,7 @@ function webpackConfig(args: any): webpack.Configuration {
 		module.rules.push({
 			test: /src[\\\/].*\.ts(x)?$/,
 			use: {
-				loader: 'istanbul-instrumenter-loader',
+				loader: '@dojo/webpack-contrib/istanbul-loader',
 				options: instrumenterOptions
 			},
 			enforce: 'post'


### PR DESCRIPTION
The regular `istanbul-instrumenter-loader` was being fussy and including the loader paths in the coverage report, resulting in mass hysteria.  Using the one from webpack-contrib solves the issue!

To test, I compared the results from a fresh copy of `@dojo/widgets` to a copy generated using this new loader. The results are identical! 🎉 