### PR TITLE
Support externals and ignore parsing blocks

### DIFF
--- a/src/dev.config.ts
+++ b/src/dev.config.ts
@@ -1,6 +1,7 @@
 import * as CleanWebpackPlugin from 'clean-webpack-plugin';
 import * as path from 'path';
 import * as webpack from 'webpack';
+import ExternalLoaderPlugin from '@dojo/webpack-contrib/external-loader-plugin/ExternalLoaderPlugin';
 import baseConfigFactory from './base.config';
 
 const removeEmpty = (items: any[]) => items.filter(item => item);
@@ -13,6 +14,13 @@ function webpackConfig(args: any): webpack.Configuration {
 
 	config.plugins = removeEmpty([
 		...plugins!,
+		args.externals &&
+			args.externals.dependencies &&
+			new ExternalLoaderPlugin({
+				dependencies: args.externals.dependencies,
+				hash: true,
+				outputPath: args.externals.outputPath
+			}),
 		args.target !== 'lib' && new CleanWebpackPlugin([location], { root: outputPath, verbose: false })
 	]);
 

--- a/src/dist.config.ts
+++ b/src/dist.config.ts
@@ -3,6 +3,7 @@ import * as CleanWebpackPlugin from 'clean-webpack-plugin';
 import * as path from 'path';
 import webpack = require('webpack');
 import * as WebpackChunkHash from 'webpack-chunk-hash';
+import ExternalLoaderPlugin from '@dojo/webpack-contrib/external-loader-plugin/ExternalLoaderPlugin';
 import baseConfigFactory from './base.config';
 
 const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
@@ -34,6 +35,13 @@ function webpackConfig(args: any): webpack.Configuration {
 
 	config.plugins = removeEmpty([
 		...plugins!,
+		args.externals &&
+			args.externals.dependencies &&
+			new ExternalLoaderPlugin({
+				dependencies: args.externals.dependencies,
+				hash: true,
+				outputPath: args.externals.outputPath
+			}),
 		args.target !== 'lib' &&
 			new BundleAnalyzerPlugin({
 				analyzerMode: 'static',


### PR DESCRIPTION
Support externals in cli-build widget (lifted straight from cli-build-app). Don't parse block files as part of the build as not supported (cli-build-app only).