### PR TITLE
Use classes map loader to support composes for the lib build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -555,11 +555,11 @@
       }
     },
     "@dojo/webpack-contrib": {
-      "version": "7.0.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@dojo/webpack-contrib/-/webpack-contrib-7.0.0-alpha.2.tgz",
-      "integrity": "sha512-4x/PWMgIpNd7jZnVaUxHFSN2hV5EAiETBfw08IRAdMSyPOX9v6ipy/BlG4z7JsU8kvr743AvMZYhgo+vE0EaWg==",
+      "version": "7.0.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@dojo/webpack-contrib/-/webpack-contrib-7.0.0-alpha.4.tgz",
+      "integrity": "sha512-ANUj+bm4uM4H1L26qJDtqUgD4A+Yi0eto+kv8DTpqaFSgviGNQvTeAda4R1YSQFoWdYoWEKBi3UabOLflKc6nw==",
       "requires": {
-        "@dojo/framework": "7.0.0-alpha.2",
+        "@dojo/framework": "7.0.0-alpha.4",
         "acorn": "6.1.1",
         "acorn-dynamic-import": "4.0.0",
         "acorn-walk": "6.1.1",
@@ -600,9 +600,9 @@
       },
       "dependencies": {
         "@dojo/framework": {
-          "version": "7.0.0-alpha.2",
-          "resolved": "https://registry.npmjs.org/@dojo/framework/-/framework-7.0.0-alpha.2.tgz",
-          "integrity": "sha512-QjvQgDrUdpWoRT9UWjlyzvukWhjqwDLQgj0hAgTkCXlC/1q95KFAtH7rgrjwY654j5sXEZHKDgrX45PbPLsyXQ==",
+          "version": "7.0.0-alpha.4",
+          "resolved": "https://registry.npmjs.org/@dojo/framework/-/framework-7.0.0-alpha.4.tgz",
+          "integrity": "sha512-CmciKG2sWhW5+jDo5WQF/2np4jouwDfelf/U3SLMzQ9L9lG+eQPDjDPfFFVgN2N+5OxoczP3dDoEb9CDrB5HHQ==",
           "requires": {
             "@types/cldrjs": "0.4.20",
             "@types/globalize": "0.0.34",
@@ -1845,9 +1845,9 @@
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.0.tgz",
+      "integrity": "sha512-Uvq6hVe90D0B2WEnUqtdgY1bATGz3mw33nH9Y+dmA+w5DHvUmBgkr5rM/KCHpCsiFNRUfokW/szpPPgMK2hm4A=="
     },
     "axios": {
       "version": "0.18.1",
@@ -5055,9 +5055,9 @@
       }
     },
     "ext": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.2.1.tgz",
-      "integrity": "sha512-x+OKKC57tNiLhDW26UmWtvQBpvO+2wxdC/A0jP7RkmjAc4gze9/U98hQyIYJUzo9A+o9ntMHpC+LH3pWMSbrVQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.3.0.tgz",
+      "integrity": "sha512-LErT9cIGZZjSvFkyocVXXeYlj7z8xiA+4oQlM9cX4X/Kfc18cefv3Dd9mNKwFuzUJ7neMMAQz1u1r3gBa/6wGg==",
       "requires": {
         "type": "^2.0.0"
       },
@@ -6038,6 +6038,27 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "generic-names": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/generic-names/-/generic-names-1.0.3.tgz",
+      "integrity": "sha1-LXhqEhruUIh2eWk56OO/+DbCCRc=",
+      "requires": {
+        "loader-utils": "^0.2.16"
+      },
+      "dependencies": {
+        "loader-utils": {
+          "version": "0.2.17",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+          "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
+          "requires": {
+            "big.js": "^3.1.3",
+            "emojis-list": "^2.0.0",
+            "json5": "^0.5.0",
+            "object-assign": "^4.0.1"
+          }
+        }
+      }
     },
     "get-caller-file": {
       "version": "1.0.3",
@@ -8859,6 +8880,11 @@
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
     },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+    },
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
@@ -11276,6 +11302,18 @@
         }
       }
     },
+    "postcss-modules": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/postcss-modules/-/postcss-modules-1.4.1.tgz",
+      "integrity": "sha512-btTrbK+Xc3NBuYF8TPBjCMRSp5h6NoQ1iVZ6WiDQENIze6KIYCSf0+UFQuV3yJ7gRHA+4AAtF8i2jRvUpbBMMg==",
+      "requires": {
+        "css-modules-loader-core": "^1.1.0",
+        "generic-names": "^1.0.3",
+        "lodash.camelcase": "^4.3.0",
+        "postcss": "^7.0.1",
+        "string-hash": "^1.1.1"
+      }
+    },
     "postcss-modules-extract-imports": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.1.0.tgz",
@@ -12652,9 +12690,9 @@
       "integrity": "sha512-M2AelyJDVR/oLnToJLtuDJRBBWUGUvvGigj1411hXhAdyFWqMaqHp7TixW3FpiLuVaikIcR1QL+zqoJoZlOgpg=="
     },
     "resolve": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.13.0.tgz",
-      "integrity": "sha512-HHZ3hmOrk5SvybTb18xq4Ek2uLqLO5/goFCYUyvn26nWox4hdlKlfC/+dChIZ6qc4ZeYcN9ekTz0yyHsFgumMw==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.13.1.tgz",
+      "integrity": "sha512-CxqObCX8K8YtAhOBRg+lrcdn+LK+WYOS8tSjqSFbjtrI5PnS63QPhZl4+yKfrU9tdsbMu9Anr/amegT87M9Z6w==",
       "requires": {
         "path-parse": "^1.0.6"
       }
@@ -13578,6 +13616,11 @@
       "integrity": "sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==",
       "dev": true
     },
+    "string-hash": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
+      "integrity": "sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs="
+    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -14199,9 +14242,9 @@
       }
     },
     "ts-node": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.5.2.tgz",
-      "integrity": "sha512-W1DK/a6BGoV/D4x/SXXm6TSQx6q3blECUzd5TN+j56YEMX3yPVMpHsICLedUw3DvGF3aTQ8hfdR9AKMaHjIi+A==",
+      "version": "8.5.4",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.5.4.tgz",
+      "integrity": "sha512-izbVCRV68EasEPQ8MSIGBNK9dc/4sYJJKYA+IarMQct1RtEot6Xp0bXuClsbUSnKpg50ho+aOAx8en5c+y4OFw==",
       "requires": {
         "arg": "^4.1.0",
         "diff": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
   },
   "dependencies": {
     "@dojo/framework": "7.0.0-alpha.3",
-    "@dojo/webpack-contrib": "7.0.0-alpha.2",
+    "@dojo/webpack-contrib": "7.0.0-alpha.4",
     "chalk": "2.4.1",
     "clean-webpack-plugin": "1.0.0",
     "cli-columns": "3.1.2",
@@ -120,6 +120,7 @@
     "pkg-dir": "2.0.0",
     "postcss-import": "12.0.0",
     "postcss-loader": "3.0.0",
+    "postcss-modules": "1.4.1",
     "postcss-preset-env": "5.3.0",
     "slash": "1.0.0",
     "source-map-loader-cli": "0.0.1",


### PR DESCRIPTION
In order to support composes for the library target composes needs to be resolved within each asset using postcss-modules and then the mappings need to be injected into the css-loader result which ensure that the correct js mappings are created.