### PR TITLE
Deal with standard `.css` files for library target

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -406,9 +406,9 @@
       }
     },
     "@dojo/framework": {
-      "version": "7.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@dojo/framework/-/framework-7.0.0-alpha.3.tgz",
-      "integrity": "sha512-NbagpENJR0sArFopGUFXF/iqyVM8q8y2QXEzTTIz8Z1IG8taOYntqehITB0fcdt7K7jV0YzC6ScoG1LC1hS5lw==",
+      "version": "7.0.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@dojo/framework/-/framework-7.0.0-alpha.4.tgz",
+      "integrity": "sha512-CmciKG2sWhW5+jDo5WQF/2np4jouwDfelf/U3SLMzQ9L9lG+eQPDjDPfFFVgN2N+5OxoczP3dDoEb9CDrB5HHQ==",
       "requires": {
         "@types/cldrjs": "0.4.20",
         "@types/globalize": "0.0.34",
@@ -599,27 +599,6 @@
         "wrapper-webpack-plugin": "2.0.0"
       },
       "dependencies": {
-        "@dojo/framework": {
-          "version": "7.0.0-alpha.4",
-          "resolved": "https://registry.npmjs.org/@dojo/framework/-/framework-7.0.0-alpha.4.tgz",
-          "integrity": "sha512-CmciKG2sWhW5+jDo5WQF/2np4jouwDfelf/U3SLMzQ9L9lG+eQPDjDPfFFVgN2N+5OxoczP3dDoEb9CDrB5HHQ==",
-          "requires": {
-            "@types/cldrjs": "0.4.20",
-            "@types/globalize": "0.0.34",
-            "@webcomponents/webcomponentsjs": "1.1.0",
-            "cldrjs": "0.5.0",
-            "cross-fetch": "3.0.2",
-            "css-select-umd": "1.3.0-rc0",
-            "diff": "3.5.0",
-            "globalize": "1.4.0",
-            "immutable": "3.8.2",
-            "intersection-observer": "0.4.2",
-            "pepjs": "0.4.2",
-            "resize-observer-polyfill": "1.5.0",
-            "tslib": "1.9.3",
-            "web-animations-js": "2.3.1"
-          }
-        },
         "camelcase": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
@@ -2124,9 +2103,9 @@
       }
     },
     "bluebird": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.1.tgz",
-      "integrity": "sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg=="
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "bn.js": {
       "version": "4.11.8",
@@ -2314,13 +2293,13 @@
       }
     },
     "browserslist": {
-      "version": "4.7.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.7.3.tgz",
-      "integrity": "sha512-jWvmhqYpx+9EZm/FxcZSbUZyDEvDTLDi3nSAKbzEkyWvtI0mNSmUosey+5awDW1RUlrgXbQb5A6qY1xQH9U6MQ==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.0.tgz",
+      "integrity": "sha512-HYnxc/oLRWvJ3TsGegR0SRL/UDnknGq2s/a8dYYEO+kOQ9m9apKoS5oiathLKZdh/e9uE+/J3j92qPlGD/vTqA==",
       "requires": {
-        "caniuse-lite": "^1.0.30001010",
-        "electron-to-chromium": "^1.3.306",
-        "node-releases": "^1.1.40"
+        "caniuse-lite": "^1.0.30001012",
+        "electron-to-chromium": "^1.3.317",
+        "node-releases": "^1.1.41"
       }
     },
     "buffer": {
@@ -2519,9 +2498,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001012",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001012.tgz",
-      "integrity": "sha512-7RR4Uh04t9K1uYRWzOJmzplgEOAXbfK72oVNokCdMzA67trrhPzy93ahKk1AWHiA0c58tD2P+NHqxrA8FZ+Trg=="
+      "version": "1.0.30001013",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001013.tgz",
+      "integrity": "sha512-hOAXaWKuq/UVFgYawxIOdPdyMQdYcwOCDOjnZcKn7wCgFUrhP7smuNZjGLuJlPSgE6aRA4cRJ+bGSrhtEt7ZAg=="
     },
     "capture-stack-trace": {
       "version": "1.0.1",
@@ -4605,9 +4584,9 @@
       "integrity": "sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA=="
     },
     "electron-to-chromium": {
-      "version": "1.3.314",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.314.tgz",
-      "integrity": "sha512-IKDR/xCxKFhPts7h+VaSXS02Z1mznP3fli1BbXWXeN89i2gCzKraU8qLpEid8YzKcmZdZD3Mly3cn5/lY9xsBQ=="
+      "version": "1.3.321",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.321.tgz",
+      "integrity": "sha512-jJy/BZK2s2eAjMPXVMSaCmo7/pSY2aKkfQ+LoAb5Wk39qAhyP9r8KU74c4qTgr9cD/lPUhJgReZxxqU0n5puog=="
     },
     "elegant-spinner": {
       "version": "1.0.1",
@@ -5055,9 +5034,9 @@
       }
     },
     "ext": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.3.0.tgz",
-      "integrity": "sha512-LErT9cIGZZjSvFkyocVXXeYlj7z8xiA+4oQlM9cX4X/Kfc18cefv3Dd9mNKwFuzUJ7neMMAQz1u1r3gBa/6wGg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
+      "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
       "requires": {
         "type": "^2.0.0"
       },
@@ -5196,9 +5175,9 @@
       "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
     },
     "fast-glob": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.1.0.tgz",
-      "integrity": "sha512-TrUz3THiq2Vy3bjfQUB2wNyPdGBeGmdjbzzBLhfHN4YFurYptCKwGq/TfiRavbGywFRzY6U2CdmQ1zmsY5yYaw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.1.1.tgz",
+      "integrity": "sha512-nTCREpBY8w8r+boyFYAx21iL6faSsQynliPHM4Uf56SbkyohCNxpVPEH9xrF5TXKy+IsjkPUHDKiUkzBVRXn9g==",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -12079,9 +12058,9 @@
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "psl": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.4.0.tgz",
-      "integrity": "sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.5.0.tgz",
+      "integrity": "sha512-4vqUjKi2huMu1OJiLhi3jN6jeeKvMZdI1tYgi/njW5zV52jNLgSAZSdN16m9bJFe61/cT8ulmw4qFitV9QRsEA=="
     },
     "public-encrypt": {
       "version": "4.0.3",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "typescript": "3.4.5"
   },
   "dependencies": {
-    "@dojo/framework": "7.0.0-alpha.3",
+    "@dojo/framework": "7.0.0-alpha.4",
     "@dojo/webpack-contrib": "7.0.0-alpha.4",
     "chalk": "2.4.1",
     "clean-webpack-plugin": "1.0.0",


### PR DESCRIPTION
**Enhancement**

Ensure that standard css files are processed correctly, without css modularising the class names.

1) Imports from dependencies or the project will be inlined in the css file.
1) URL imports such as `https://unpkg.com/tailwindcss@^1.0/dist/tailwind.min.css`

