### PR TITLE
Fix rules for files

### DIFF
--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -297,12 +297,12 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 					test: new RegExp(`globalize(\\${path.sep}|$)`),
 					loader: 'imports-loader?define=>false'
 				},
-				isLib && {
+				{
 					exclude: allPaths,
 					test: /.*\.(gif|png|jpe?g|svg|eot|ttf|woff|woff2)$/i,
 					loader: 'file-loader',
 					options: {
-						emitFile: false
+						emitFile: !isLib
 					}
 				},
 				{


### PR DESCRIPTION
I think when we adjusted these rules we just left a hole in the file loader rules for non lib builds.

Here's a repro with a built version of `cli-build-widget` with these changes
https://github.com/maier49/bug-repro

Fixes #90 