### PR TITLE
Custom element loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,8 +96,8 @@
     "typescript": "3.4.5"
   },
   "dependencies": {
-    "@dojo/framework": "~7.0.0",
-    "@dojo/webpack-contrib": "~7.0.0",
+    "@dojo/framework": "8.0.0-alpha.1",
+    "@dojo/webpack-contrib": "8.0.0-alpha.1",
     "chalk": "2.4.1",
     "clean-webpack-plugin": "1.0.0",
     "cli-columns": "3.1.2",

--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -171,7 +171,7 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 					vendors: false,
 
 					common: {
-						name: 'bootstrap',
+						name: 'common',
 						minChunks: 2,
 						chunks: 'all',
 						priority: 10,

--- a/src/base.config.ts
+++ b/src/base.config.ts
@@ -175,6 +175,24 @@ export default function webpackConfigFactory(args: any): webpack.Configuration {
 			];
 			return entry;
 		}, {}),
+		optimization: {
+			splitChunks: {
+				cacheGroups: {
+					default: false,
+					vendors: false,
+
+					common: {
+						name: 'bootstrap',
+						minChunks: 2,
+						chunks: 'all',
+						priority: 10,
+						reuseExistingChunk: true,
+						enforce: true,
+						test: ({ resource }) => /node_modules/.test(resource)
+					}
+				}
+			}
+		},
 		node: { dgram: 'empty', net: 'empty', tls: 'empty', fs: 'empty' },
 		output: {
 			chunkFilename: isLib ? '[name].js' : `[name]-${packageJson.version}.js`,

--- a/src/template/custom-element.js
+++ b/src/template/custom-element.js
@@ -1,4 +1,9 @@
 var registerCustomElement = require('@dojo/framework/core/registerCustomElement').default;
 
-var defaultExport = widgetFactory.default;
-defaultExport && registerCustomElement(defaultExport);
+function useDefault(p) {
+	return p.then(function (r) {
+		return r.default;
+	});
+}
+
+

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -15,7 +15,7 @@
     "build:lib-app": "dojo build app && shx mv output/dist output/dist-lib-evergreen"
   },
   "dependencies": {
-    "@dojo/framework": "7.0.0-alpha.2",
+    "@dojo/framework": "8.0.0-alpha.1",
     "@webcomponents/custom-elements": "1.0.8",
     "tslib": "~1.9.0",
     "typescript": "3.4.5"

--- a/test-app/src/evergreen.html
+++ b/test-app/src/evergreen.html
@@ -5,10 +5,6 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<script src="../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
 	<script src="./bootstrap-1.0.0.js"></script>
-	<script src="./menu-1.0.0.js"></script>
-	<script src="./menu-item-1.0.0.js"></script>
-	<link rel="stylesheet" href="./menu-1.0.0.css" />
-	<link rel="stylesheet" href="./menu-item-1.0.0.css" />
 </head>
 <body>
 	<div class="menu-container">

--- a/test-app/src/evergreen.html
+++ b/test-app/src/evergreen.html
@@ -4,6 +4,7 @@
 	<title>custom-element</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<script src="../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
+	<script src="./bootstrap-1.0.0.js"></script>
 	<script src="./menu-1.0.0.js"></script>
 	<script src="./menu-item-1.0.0.js"></script>
 	<link rel="stylesheet" href="./menu-1.0.0.css" />

--- a/test-app/src/legacy.html
+++ b/test-app/src/legacy.html
@@ -5,6 +5,7 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<script src="../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
 	<script src="../../node_modules/@webcomponents/webcomponentsjs/custom-elements-es5-adapter.js"></script>
+	<script src="./bootstrap-1.0.0.js"></script>
 	<script src="./menu-1.0.0.js"></script>
 	<script src="./menu-item-1.0.0.js"></script>
 	<link rel="stylesheet" href="./menu-1.0.0.css" />

--- a/test-app/src/legacy.html
+++ b/test-app/src/legacy.html
@@ -6,10 +6,6 @@
 	<script src="../../node_modules/@webcomponents/custom-elements/custom-elements.min.js"></script>
 	<script src="../../node_modules/@webcomponents/webcomponentsjs/custom-elements-es5-adapter.js"></script>
 	<script src="./bootstrap-1.0.0.js"></script>
-	<script src="./menu-1.0.0.js"></script>
-	<script src="./menu-item-1.0.0.js"></script>
-	<link rel="stylesheet" href="./menu-1.0.0.css" />
-	<link rel="stylesheet" href="./menu-item-1.0.0.css" />
 </head>
 <body>
 	<div class="menu-container">


### PR DESCRIPTION
Changes described in dojo/framework#770 and some additional test changes. Depends on dojo/framework#825 as well as dojo/webpack-contrib#295

There's also one (potentially significant) caveat with these. changes. The bootstrap file and all the dynamically loaded files for individual widgets will end up in the `dist` folder the same way widget custom element scripts do now. However, when individual widget files are linked in `index.html` they are each copied over. Here only the bootstrap file is linked and so only it is copied over. The rest of the files (or the entire directory) for any widgets that might be loaded would need to be added to the externals configuration and copied over explicitly.